### PR TITLE
QMUILinkTextView 添加允许设置显示链接下划线，链接最大字数限制支持三个点显示

### DIFF
--- a/qmui/src/main/java/com/qmuiteam/qmui/link/QMUILinkify.java
+++ b/qmui/src/main/java/com/qmuiteam/qmui/link/QMUILinkify.java
@@ -278,7 +278,7 @@ public class QMUILinkify {
         }
 
         if ((mask & MAP_ADDRESSES) != 0) {
-            gatherMapLinks(links, text);
+            gatherMapLinks(links, text,maxLength);
         }
 
         pruneOverlaps(links);
@@ -436,7 +436,7 @@ public class QMUILinkify {
         return hasMatches;
     }
 
-    private static void applyLink(String url, int start, int end, Spannable text, final ColorStateList linkColor, final ColorStateList bgColor, boolean allowUnderline, QMUIOnSpanClickListener l) {
+    private static void applyLink(String url, int start, int end, Spannable text, final ColorStateList linkColor, final ColorStateList bgColor, final boolean allowUnderline, QMUIOnSpanClickListener l) {
         text.setSpan(new StyleableURLSpan(url, l) {
 
             @Override

--- a/qmui/src/main/java/com/qmuiteam/qmui/widget/textview/QMUILinkTextView.java
+++ b/qmui/src/main/java/com/qmuiteam/qmui/widget/textview/QMUILinkTextView.java
@@ -70,7 +70,7 @@ public class QMUILinkTextView extends AppCompatTextView implements QMUIOnSpanCli
     /**
      * 是否允许显示链接下划线
      */
-    private boolean mAllowUnderLine = true;
+    private boolean mAllowUnderLine = false;
 
     private int mAutoLinkMaskCompat;
     private OnLinkClickListener mOnLinkClickListener;

--- a/qmui/src/main/res/values/qmui_attrs.xml
+++ b/qmui/src/main/res/values/qmui_attrs.xml
@@ -239,6 +239,8 @@
     <declare-styleable name="QMUILinkTextView">
         <attr name="qmui_linkBackgroundColor" format="color"/>
         <attr name="qmui_linkTextColor" format="color"/>
+        <attr name="qmui_allowUnderLine" format="boolean" />
+        <attr name="qmui_ellipsizeEnable" format="boolean" />
     </declare-styleable>
 
     <!-- RoundWidget start -->

--- a/qmuidemo/src/main/java/com/qmuiteam/qmuidemo/fragment/components/QDLinkTextViewFragment.java
+++ b/qmuidemo/src/main/java/com/qmuiteam/qmuidemo/fragment/components/QDLinkTextViewFragment.java
@@ -24,6 +24,7 @@ public class QDLinkTextViewFragment extends BaseFragment {
 
     @BindView(R.id.topbar) QMUITopBar mTopBar;
     @BindView(R.id.link_text_view) QMUILinkTextView mLinkTextView;
+    @BindView(R.id.link_text_view2) QMUILinkTextView mLinkTv2;
 
 
     @Override
@@ -52,6 +53,9 @@ public class QDLinkTextViewFragment extends BaseFragment {
 //                Toast.makeText(getContext(), "forceEventToParent", Toast.LENGTH_SHORT).show();
 //            }
 //        });
+        mLinkTv2.setOnLinkClickListener(mOnLinkClickListener);
+        mLinkTv2.setText(R.string.linkTextVIew_allowUnderLine_maxLimit_word);
+
         return view;
     }
 

--- a/qmuidemo/src/main/res/layout/fragment_link_texview_layout.xml
+++ b/qmuidemo/src/main/res/layout/fragment_link_texview_layout.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             xmlns:app="http://schemas.android.com/apk/res-auto"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent"
-             android:background="?attr/app_primary_color">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="?attr/app_primary_color">
 
     <com.qmuiteam.qmui.widget.QMUITopBar
         android:id="@+id/topbar"
@@ -33,6 +34,18 @@
             android:text="@string/linkTextView_auto_identify_word"
             app:qmui_linkBackgroundColor="@color/s_app_color_gray"
             app:qmui_linkTextColor="@color/s_app_color_blue_2"/>
+
+        <com.qmuiteam.qmui.widget.textview.QMUILinkTextView
+            android:id="@+id/link_text_view2"
+            style="@style/QDCommonDescription"
+            android:layout_marginBottom="20dp"
+            android:gravity="left"
+            app:qmui_ellipsizeEnable="true"
+            app:qmui_allowUnderLine="true"
+            tools:text="@string/linkTextVIew_allowUnderLine_maxLimit_word"
+            android:maxLength="150"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
     </LinearLayout>
 

--- a/qmuidemo/src/main/res/values/strings.xml
+++ b/qmuidemo/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <!-- LinkTextView 展示界面 -->
     <string name="linkTextView_auto_identify">URL/Mail/Tel自动识别</string>
     <string name="linkTextView_auto_identify_word">可以自动识别网页链接，例如 http://www.qmuiteam.com。\n可以自动识别电话号码，例如 13600000000。\n也可以识别邮件地址，例如 qmuiteam@gmail.com。\n我们可以为其添加自定义的点击事件。</string>
+    <string name="linkTextVIew_allowUnderLine_maxLimit_word">可以允许是否设置显示链接拥有下划线 例如 http://www.qmuiteam.com ,超长链接超过指定长度显示三个点，依然可以自动识别电话号码等，例如 13600000000，并且如果如果链接所在的连接地址超过指定长度，则不显示链接，https://www.baidu.com/#iact=wiseindex%2Ftabs%2Fnews%2Factivity%2Fnewsdetail%3D%257B%2522linkData%2522%253A%257B%2522name%2522%253A%2522iframe%252Fmib-iframe%2522%252C%2522id%2522%253A%2522feed%2522%252C%2522index%2522%253A0%252C%2522url%2522%253A%2522https%253A%252F%252Fmbd.baidu.com%252Fnewspage%252Fdata%252Flandingpage%253Fs_type%253Dnews%2526dsp%253Dwise%2526context%253D%25257B%252522nid%252522%25253A%252522news_9441325276163769821%252522%25257D%2526pageType%253D1%2526n_type%253D1%2526p_from%253D-1%2526rec_src%253D52%2526innerIframe%253D1%2522%252C%2522isThird%2522%253Afalse%252C%2522title%2522%253Anull%257D%257D</string>
 
     <!-- SpanTouchFixTextView -->
     <string name="spanTouchFix_description">QMUISpanTouchFixTextView 主要用于修正 TextView 添加 ClickSpan 后的点击行为与事件传递</string>


### PR DESCRIPTION
通过自定义属性设置是否允许添加显示链接是否有下划线。因为在使用中需要对超长的链接进行字数限制，或者行数限制，TextView的原因导致没法实现三个点末尾显示，并且如果限制行数，QMUITextView 点击会有滑动的情况，无法触发链接点击事件，限制通过对text 先进行处理解决了这个问题。